### PR TITLE
Example exam fix

### DIFF
--- a/2019-20-2/vizsga_minta/minta1/Feladatok.hs
+++ b/2019-20-2/vizsga_minta/minta1/Feladatok.hs
@@ -143,6 +143,7 @@ data Statement
   | While Exp Program       -- while e do p1 end
   | If Exp Program Program  -- if e then p1 else p2 end
   | Block Program           -- {p1}       (lokális scope)
+  | Skip                    -- skip
 
   deriving Show
 
@@ -186,7 +187,7 @@ string' :: String -> Parser ()
 string' s = string s <* ws
 
 keywords :: [String]
-keywords = ["not", "and", "while", "do", "if", "end", "true", "false"]
+keywords = ["not", "and", "while", "do", "if", "end", "true", "false", "skip"]
 
 pIdent :: Parser String
 pIdent = do
@@ -247,6 +248,7 @@ pStatement =
             <*> (string' "then" *> pProgram)
             <*> (string' "else" *> pProgram <* string' "end"))
     <|> (Block <$> (char' '{' *> pProgram <* char' '}'))
+    <|> (Skip <$ string' "skip")
 
 pSrc :: Parser Program
 pSrc = ws *> pProgram <* eof
@@ -364,6 +366,8 @@ evalSt s = case s of
       Left _ -> error "type error: expected a Bool condition in \"if\" expression"
   Block p ->
     newScope (evalProg p)
+  Skip ->
+    pure ()
 
 evalProg :: Program -> Eval ()
 evalProg = mapM_ evalSt

--- a/2019-20-2/vizsga_minta/minta1/Feladatok.md
+++ b/2019-20-2/vizsga_minta/minta1/Feladatok.md
@@ -128,7 +128,7 @@ A `LogStr` és a `LogInt` kulcsszavaknak számítanak.
 A `LogStr` szintaxisa "LogStr" kulcsszó után egy string literál. Példa:
 
 ```haskell
-If (x == 10) then LogStr "kutya" else skip
+if (x == 10) then LogStr "kutya" else skip end
 ```
 
 A `LogInt` szintaxisa "LogInt" kulcsszó után egy kifejezés. Példa:

--- a/2019-20-2/vizsga_minta/minta1/Solutions.hs
+++ b/2019-20-2/vizsga_minta/minta1/Solutions.hs
@@ -210,6 +210,7 @@ data Statement
   | While Exp Program       -- while e do p1 end
   | If Exp Program Program  -- if e then p1 else p2 end
   | Block Program           -- {p1}       (lokális scope)
+  | Skip                    -- skip
 
   | LogStr String
   | LogInt Exp
@@ -255,7 +256,7 @@ string' :: String -> Parser ()
 string' s = string s <* ws
 
 keywords :: [String]
-keywords = ["not", "and", "while", "do", "if", "end", "true", "false", "LogStr", "LogInt"]
+keywords = ["not", "and", "while", "do", "if", "end", "true", "false", "skip",  "LogStr", "LogInt"]
 
 pIdent :: Parser String
 pIdent = do
@@ -319,6 +320,7 @@ pStatement =
             <*> (string' "then" *> pProgram)
             <*> (string' "else" *> pProgram <* string' "end"))
     <|> (Block <$> (char' '{' *> pProgram <* char' '}'))
+    <|> (Skip <$ string' "skip")
     <|> (LogStr <$> (string' "LogStr" *> pStringLit))
     <|> (LogInt <$> (string' "LogInt" *> pExp))
 
@@ -438,6 +440,8 @@ evalSt s = case s of
       Left _ -> error "type error: expected a Bool condition in \"if\" expression"
   Block p ->
     newScope (evalProg p)
+  Skip ->
+    pure ()
   LogStr str ->
     modify (\(env, log) -> (env, str:log))
   LogInt e -> do


### PR DESCRIPTION
There is an example in the example exam (`minta1`) that is not in sync with the implementation: `If (x == 10) then LogStr "kutya" else skip`.
* The `if` is lowercase and ends with `end` keyword.
* `skip` is not implemented